### PR TITLE
added project_root in the manager spacelift_stack

### DIFF
--- a/manager-stack/main.tf
+++ b/manager-stack/main.tf
@@ -26,6 +26,7 @@ resource "spacelift_stack" "manager" {
   branch         = var.branch
   description    = var.stack_description
   name           = var.stack_name
+  project_root   = var.project_root
   repository     = var.repository
 }
 

--- a/manager-stack/variables.tf
+++ b/manager-stack/variables.tf
@@ -11,7 +11,7 @@ variable "import_state" {
 }
 
 variable "project_root" {
-  default     = ""
+  default     = null
   description = "Path to the folder containing the Terraform code, in case of a monorepo"
   type        = string
 }
@@ -37,7 +37,7 @@ variable "spacelift_api_key_secret" {
 }
 
 variable "stack_description" {
-  default     = ""
+  default     = null
   description = "Description for the stack"
   type        = string
 }


### PR DESCRIPTION
The project_root variable was unused, so I've added it inside the stack. 
I can potentially remove it from all the definitions if we don't want to use it.