### PR TITLE
Add `github_enterpise` block, update documentation, update provider version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ When the Terraform code is ready, commit it to a repository.
 
 ### Create a manager Spacelift stack
 
+> :warning: **Check out the VCS system integation**
+> If you were using https://docs.spacelift.io/integrations/source-control/github#setting-up-the-custom-application
+> set a correct `namespace` variable in `manager-stack/terraform.tfvars`
+> and uncomment `github_enterpise` block in `manager-stack/main.tf` file.
+
 It is now time to create a Spacelift stack that will point to the commited Terraform code that manages your Spacelift resources.
 
 - Copy the example `manager-stack.example.tfvars` file into `manager-stack.tfvars` .

--- a/manager-stack.example.tfvars
+++ b/manager-stack.example.tfvars
@@ -4,6 +4,9 @@ stack_name = "Spacelift Manager"
 # Description for the stack
 stack_description = "Spacelift resources manager"
 
+# Name of your GitHub Enterprise organisation or GitHub account
+# namespace = "change-me-to-your-organisation-or-account-name"
+
 # Name of the repository to associate with the stack
 repository = "spacelift"
 

--- a/manager-stack/main.tf
+++ b/manager-stack/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     spacelift = {
       source  = "spacelift-io/spacelift"
-      version = "~> 0.1"
+      version = "~> 1.0"
     }
   }
 }
@@ -28,6 +28,11 @@ resource "spacelift_stack" "manager" {
   name           = var.stack_name
   project_root   = var.project_root
   repository     = var.repository
+  # If you are using GitHub custom app installation https://docs.spacelift.io/integrations/source-control/github#setting-up-the-custom-application
+  # uncomment the following lines
+  # github_enterprise {
+  #   namespace = var.namespace
+  # }
 }
 
 resource "spacelift_run" "manager" {


### PR DESCRIPTION
Update provider version.
Add `github_enterprise` block.

**Rationale**

I've created my Spacelift account using Google authentication and therefore I used https://docs.spacelift.io/integrations/source-control/github#setting-up-the-custom-application to set up VCS integration between Spacelift and GitHub.

I've added several lines to the Terraform code and README.md, so users won't be confused.

I appreciate feedback or the format and open to update the change.

PS: My experience with the migration kit is documented here https://dev-tau-seven.vercel.app/posts/migration-from-terraform-to-spacelift#use-spacelift-migration-kit
