### PR TITLE
Add namespace to variables.tf for manager-stack.

### DIFF
--- a/manager-stack/variables.tf
+++ b/manager-stack/variables.tf
@@ -49,3 +49,7 @@ variable "stack_name" {
   description = "Name of the manager stack"
   type        = string
 }
+
+variable "namespace" {
+  description = "VCS Namespace"
+}

--- a/manager-stack/variables.tf
+++ b/manager-stack/variables.tf
@@ -52,4 +52,5 @@ variable "stack_name" {
 
 variable "namespace" {
   description = "VCS Namespace"
+  type        = string
 }

--- a/manager-stack/variables.tf
+++ b/manager-stack/variables.tf
@@ -53,4 +53,5 @@ variable "stack_name" {
 variable "namespace" {
   description = "VCS Namespace"
   type        = string
+  default     = null
 }


### PR DESCRIPTION
Currently, setting `namespace` in manager-stack.tfvars if you are using the GitHub custom app will fail because it's absent from `variables.tf`.  This fixes the issue.
