### PR TITLE
fix: import-tfc-state.sh curl authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ STATE_DOWNLOAD_URL=$(curl -sSL --fail \
   "https://app.terraform.io/api/v2/workspaces/${TFC_WORKSPACE_ID}/current-state-version" \
   | jq -r '.data.attributes."hosted-state-download-url"' )
 
-curl -sSL --fail -o state.tfstate "${STATE_DOWNLOAD_URL}"
+curl -sSL --fail --header "Authorization: Bearer $TFC_TOKEN" -o state.tfstate "${STATE_DOWNLOAD_URL}"
 terraform state push -force state.tfstate
 ```
 


### PR DESCRIPTION
Added --header "Authorization: Bearer $TFC_TOKEN" to the second curl command because the script fails with a 401 while running the second curl command:

![image](https://github.com/spacelift-io/spacelift-migration-kit/assets/67458478/5040a1d2-bf66-4826-8414-6f80f3aad8f3)
