### PR TITLE
Handle version constraints

### DIFF
--- a/spacemk/__init__.py
+++ b/spacemk/__init__.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import subprocess
 from importlib.metadata import version
 from pathlib import Path
@@ -29,6 +30,16 @@ def pypi_version_to_semver(version: str) -> str:
 
 
 __version__ = pypi_version_to_semver(version("spacemk"))
+
+
+def terraform_version_to_semver(version: str | None) -> str:
+    try:
+        version_number = re.sub(r"[^\d\.]", "", version)
+        semver_version = SemVerVersion.parse(version_number)
+        return str(semver_version)
+    except Exception:
+        # KLUDGE: Stick to the latest MPL-licensed Terraform version for now
+        return "1.5.7"
 
 
 def ensure_folder_exists(path: Path | str) -> None:

--- a/spacemk/exporters/terraform.py
+++ b/spacemk/exporters/terraform.py
@@ -15,7 +15,7 @@ from python_on_whales import Container, docker
 from requests_toolbelt.utils import dump as request_dump
 from slugify import slugify
 
-from spacemk import get_tmp_subfolder, is_command_available
+from spacemk import get_tmp_subfolder, is_command_available, terraform_version_to_semver
 from spacemk.exporters import BaseExporter
 
 
@@ -180,9 +180,9 @@ class TerraformExporter(BaseExporter):
             if item.get("attributes.vcs-repo.service-provider") is None:
                 warnings.append("No VCS configuration")
 
-            if semver.match(item.get("attributes.terraform-version"), ">=1.5.7"):
+            terraform_version = terraform_version_to_semver(item.get("attributes.terraform-version"))
+            if semver.match(terraform_version, ">=1.5.7"):
                 warnings.append("BSL Terraform version")
-
             data[key]["warnings"] = ", ".join(warnings)
 
         logging.info("Stop checking workspaces data")
@@ -1266,13 +1266,8 @@ class TerraformExporter(BaseExporter):
             else:
                 vcs_namespace = None
                 vcs_repository = None
-
-            terraform_version = workspace.get("attributes.terraform-version")
-            if terraform_version == "latest":
-                # KLUDGE: Stick to the latest MPL-licensed Terraform version for now
-                terraform_version = "1.5.7"
-
-            if semver.match(workspace.get("attributes.terraform-version"), ">=1.5.7"):
+            terraform_version = terraform_version_to_semver(workspace.get("attributes.terraform-version"))
+            if semver.match(terraform_version, ">=1.5.7"):
                 terraform_workflow_tool = "CUSTOM"
             else:
                 terraform_workflow_tool = "TERRAFORM_FOSS"

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -1,0 +1,21 @@
+import pytest
+
+from spacemk import terraform_version_to_semver
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_version"),
+    [
+        (">= 1.3.0, <1.6.0", "1.5.7"),
+        ("~> 1.3.9", "1.3.9"),
+        ("~> 1.5.0", "1.5.0"),
+        ("~>1.5.7", "1.5.7"),
+        ("1.5.2", "1.5.2"),
+        ("1.6.3", "1.6.3"),
+        ("latest", "1.5.7"),
+        (None, "1.5.7"),
+    ],
+)
+def test_terraform_version_to_semver(version: str | None, expected_version: str) -> None:
+    actual_version = terraform_version_to_semver(version)
+    assert actual_version == expected_version


### PR DESCRIPTION
## Description

Thanks for all the recent updates to the migration kit! I find it much easier to use than the previous implementation.

I encountered an issue with version constraints. [Terraform versions in Terraform Cloud workspaces may have version constraints](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings), and the exporter currently raises an exception on version constraints.

For example, exporting a Terraform Cloud workspace set to Terraform version `~>1.5.0` raises `ValueError: ~>1.5.0 is not valid SemVer string`.

<details><summary>Traceback <em>(expand)</em>.</summary>

```text
spacelift-migration-kit on  main [?] is 📦 v2.0.0-dev via 🐍 v3.12.2 (spacemk-py3.12) on ☁️  (us-east-2)
❯ spacemk export
smk-latest: Pulling from jmfontaine/tfc-agent
Digest: sha256:f92a300764ad2d54a56aba3283cdbfc903901640339d03fcf9df5885753e9ba7
Status: Image is up to date for jmfontaine/tfc-agent:smk-latest
docker.io/jmfontaine/tfc-agent:smk-latest
ERROR    The command failed
         ╭──────────────────────── Traceback (most recent call last) ─────────────────────────╮
         │ /Users/brendon/dev/spacelift-migration-kit/spacemk/cli.py:76 in app                │
         │                                                                                    │
         │   73                                                                               │
         │   74 def app():                                                                    │
         │   75 │   try:                                                                      │
         │ ❱ 76 │   │   spacemk()                                                             │
         │   77 │   except Exception:                                                         │
         │   78 │   │   logging.exception("The command failed")                               │
         │   79 │   │   sys.exit(1)                                                           │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/clic │
         │ k/core.py:1157 in __call__                                                         │
         │                                                                                    │
         │   1154 │                                                                           │
         │   1155 │   def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:             │
         │   1156 │   │   """Alias for :meth:`main`."""                                       │
         │ ❱ 1157 │   │   return self.main(*args, **kwargs)                                   │
         │   1158                                                                             │
         │   1159                                                                             │
         │   1160 class Command(BaseCommand):                                                 │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/clic │
         │ k/core.py:1078 in main                                                             │
         │                                                                                    │
         │   1075 │   │   try:                                                                │
         │   1076 │   │   │   try:                                                            │
         │   1077 │   │   │   │   with self.make_context(prog_name, args, **extra) as ctx:    │
         │ ❱ 1078 │   │   │   │   │   rv = self.invoke(ctx)                                   │
         │   1079 │   │   │   │   │   if not standalone_mode:                                 │
         │   1080 │   │   │   │   │   │   return rv                                           │
         │   1081 │   │   │   │   │   # it's not safe to `ctx.exit(rv)` here!                 │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/clic │
         │ k/core.py:1688 in invoke                                                           │
         │                                                                                    │
         │   1685 │   │   │   │   super().invoke(ctx)                                         │
         │   1686 │   │   │   │   sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)      │
         │   1687 │   │   │   │   with sub_ctx:                                               │
         │ ❱ 1688 │   │   │   │   │   return _process_result(sub_ctx.command.invoke(sub_ctx)) │
         │   1689 │   │                                                                       │
         │   1690 │   │   # In chain mode we create the contexts step by step, but after the  │
         │   1691 │   │   # base command has been invoked.  Because at that point we do not   │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/clic │
         │ k/core.py:1434 in invoke                                                           │
         │                                                                                    │
         │   1431 │   │   │   echo(style(message, fg="red"), err=True)                        │
         │   1432 │   │                                                                       │
         │   1433 │   │   if self.callback is not None:                                       │
         │ ❱ 1434 │   │   │   return ctx.invoke(self.callback, **ctx.params)                  │
         │   1435 │                                                                           │
         │   1436 │   def shell_complete(self, ctx: Context, incomplete: str) -> t.List["Comp │
         │   1437 │   │   """Return a list of completions for the incomplete value. Looks     │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/clic │
         │ k/core.py:783 in invoke                                                            │
         │                                                                                    │
         │    780 │   │                                                                       │
         │    781 │   │   with augment_usage_errors(__self):                                  │
         │    782 │   │   │   with ctx:                                                       │
         │ ❱  783 │   │   │   │   return __callback(*args, **kwargs)                          │
         │    784 │                                                                           │
         │    785 │   def forward(                                                            │
         │    786 │   │   __self, __cmd: "Command", *args: t.Any, **kwargs: t.Any  # noqa: B9 │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/clic │
         │ k/decorators.py:118 in new_func                                                    │
         │                                                                                    │
         │   115 │   │   def new_func(*args: "P.args", **kwargs: "P.kwargs") -> R:            │
         │   116 │   │   │   ctx = get_current_context()                                      │
         │   117 │   │   │   obj = ctx.meta[key]                                              │
         │ ❱ 118 │   │   │   return ctx.invoke(f, obj, *args, **kwargs)                       │
         │   119 │   │                                                                        │
         │   120 │   │   return update_wrapper(new_func, f)                                   │
         │   121                                                                              │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/clic │
         │ k/core.py:783 in invoke                                                            │
         │                                                                                    │
         │    780 │   │                                                                       │
         │    781 │   │   with augment_usage_errors(__self):                                  │
         │    782 │   │   │   with ctx:                                                       │
         │ ❱  783 │   │   │   │   return __callback(*args, **kwargs)                          │
         │    784 │                                                                           │
         │    785 │   def forward(                                                            │
         │    786 │   │   __self, __cmd: "Command", *args: t.Any, **kwargs: t.Any  # noqa: B9 │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/spacemk/commands/export.py:17 in export │
         │                                                                                    │
         │   14 @pass_meta_key("config")                                                      │
         │   15 def export(config):                                                           │
         │   16 │   exporter = load_exporter(config=config.get("exporter", {}))               │
         │ ❱ 17 │   exporter.export()                                                         │
         │   18                                                                               │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/spacemk/exporters/base.py:179 in export │
         │                                                                                    │
         │   176 │   │   data = self._extract_data()                                          │
         │   177 │   │   data = self._filter_data(data)                                       │
         │   178 │   │   data = self._enrich_data(data)                                       │
         │ ❱ 179 │   │   data = self._map_data(data)                                          │
         │   180 │   │   save_normalized_data(data)                                           │
         │   181 │   │                                                                        │
         │   182 │   │   logging.info("Stop exporting data")                                  │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/spacemk/exporters/terraform.py:1326 in  │
         │ _map_data                                                                          │
         │                                                                                    │
         │   1323 │   │   │   │   #     src_data                                              │
         │   1324 │   │   │   │   # ),  # Must be after contexts due to dependency            │
         │   1325 │   │   │   │   "modules": self._map_modules_data(src_data),                │
         │ ❱ 1326 │   │   │   │   "stacks": self._map_stacks_data(src_data),                  │
         │   1327 │   │   │   │   "stack_variables": self._map_stack_variables_data(src_data) │
         │        after stacks due to dependency                                              │
         │   1328 │   │   │   }                                                               │
         │   1329 │   │   )                                                                   │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/spacemk/exporters/terraform.py:1275 in  │
         │ _map_stacks_data                                                                   │
         │                                                                                    │
         │   1272 │   │   │   │   # KLUDGE: Stick to the latest MPL-licensed Terraform versio │
         │   1273 │   │   │   │   terraform_version = "1.5.7"                                 │
         │   1274 │   │   │                                                                   │
         │ ❱ 1275 │   │   │   if semver.match(workspace.get("attributes.terraform-version"),  │
         │   1276 │   │   │   │   terraform_workflow_tool = "CUSTOM"                          │
         │   1277 │   │   │   else:                                                           │
         │   1278 │   │   │   │   terraform_workflow_tool = "TERRAFORM_FOSS"                  │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/semv │
         │ er/_deprecated.py:80 in wrapper                                                    │
         │                                                                                    │
         │    77 │   │   # https://docs.python.org/3/library/inspect.html#the-interpreter-sta │
         │    78 │   │   # better remove the interpreter stack:                               │
         │    79 │   │   del frame                                                            │
         │ ❱  80 │   │   return func(*args, **kwargs)  # type: ignore                         │
         │    81 │                                                                            │
         │    82 │   return wrapper                                                           │
         │    83                                                                              │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/semv │
         │ er/_deprecated.py:196 in match                                                     │
         │                                                                                    │
         │   193 │   >>> semver.match("1.0.0", ">1.0.0")                                      │
         │   194 │   False                                                                    │
         │   195 │   """                                                                      │
         │ ❱ 196 │   ver = Version.parse(version)                                             │
         │   197 │   return ver.match(match_expr)                                             │
         │   198                                                                              │
         │   199                                                                              │
         │                                                                                    │
         │ /Users/brendon/dev/spacelift-migration-kit/.venv/lib/python3.12/site-packages/semv │
         │ er/version.py:646 in parse                                                         │
         │                                                                                    │
         │   643 │   │   else:                                                                │
         │   644 │   │   │   match = cls._REGEX.match(version)                                │
         │   645 │   │   if match is None:                                                    │
         │ ❱ 646 │   │   │   raise ValueError(f"{version} is not valid SemVer string")        │
         │   647 │   │                                                                        │
         │   648 │   │   matched_version_parts: Dict[str, Any] = match.groupdict()            │
         │   649 │   │   if not matched_version_parts["minor"]:                               │
         ╰────────────────────────────────────────────────────────────────────────────────────╯
         ValueError: ~>1.5.0 is not valid SemVer string
```

</details>

## Changes

This PR proposes to add a simple utility function for parsing the Terraform version. The function tries to remove version constraint characters and parse the version. If any exceptions are raised, the function will return `1.5.7` as suggested by the previous code. This is not a perfectly accurate approach to version constraint handling, but it will at least help to avoid exceptions and set an approximate Terraform version.

This PR includes tests to cover the new function.

## Related

- [OpenTofu docs: version constraints](https://opentofu.org/docs/language/expressions/version-constraints/)
- [HCP Terraform (Terraform Cloud) docs: Workspaces - Settings](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/settings)
