### PR TITLE
fix: write_column should be a list

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ insert_final_newline = true
 indent_size = 2
 indent_style = space
 trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4

--- a/spacemk/exporters/base.py
+++ b/spacemk/exporters/base.py
@@ -163,11 +163,11 @@ class BaseExporter(ABC):
                 column = 0
                 for key, value in sorted(pivoted_entity_type_data.items()):
                     # Skip data structures
-                    if type(value) in [dict, list, tuple, set]:
+                    if type(value) in [dict, tuple, set]:
                         continue
 
                     worksheet.write(0, column, key)
-                    worksheet.write_column(1, column, value)
+                    worksheet.write_column(1, column, value if isinstance(value, list) else [value])
                     column += 1
 
         workbook.close()


### PR DESCRIPTION
[write_column(starting_row, column, data)](https://xlsxwriter.readthedocs.io/worksheet.html#worksheet-write-column)

write_column writes a column starting at `starting_row` and iterates over `data` incrementing the row automaticaly.

This change ensures we are always passing in a list, letting the library handle the hard work for us.