### PR TITLE
Feat: support contexts

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -9,6 +9,10 @@ exporter:
     include:
       workspaces: ^example-.*$
 
+#    # If you want to support variable sets, set this to `true`. This feature is experimental.
+#    # Default: false
+#    experimental_support_variable_sets: false
+
 generator:
 
 #  # If you use a custom app in github with spacelift, set this to `true`.

--- a/data/terraform-push/Dockerfile
+++ b/data/terraform-push/Dockerfile
@@ -1,0 +1,15 @@
+FROM hashicorp/terraform:1.5.6 as terraform
+FROM ubuntu:24.04
+
+WORKDIR /app
+
+COPY main.tf /app/main.tf
+COPY entrypoint.sh /app/entrypoint.sh
+COPY --from=terraform /bin/terraform /bin/terraform
+
+RUN mkdir -p $HOME/.terraform.d && chmod +x entrypoint.sh
+RUN DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/data/terraform-push/entrypoint.sh
+++ b/data/terraform-push/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Ensure the terraform rc directory is setup properly
+if ! test -f $HOME/.terraform.d/credentials.tfrc.json; then
+  echo "No Credentials for TFC found, exiting."
+  exit 1
+fi
+
+sed -i -e "s/{replace_me}/$ORG/g" main.tf
+
+terraform init
+terraform apply --auto-approve

--- a/data/terraform-push/main.tf
+++ b/data/terraform-push/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  cloud {
+    organization = "{replace_me}"
+
+    workspaces {
+      name = "SMK"
+    }
+  }
+}
+
+resource "null_resource" "nothing" {
+  triggers = {
+    always_run = timestamp()
+  }
+}

--- a/spacemk/commands/generate.py
+++ b/spacemk/commands/generate.py
@@ -13,19 +13,19 @@ from spacemk.generator import Generator
 )
 @pass_meta_key("config")
 def generate(config):
-    def default(value, _default):
+    def set_default(value, _default):
         return value if value is not None else _default
 
     generation_config = {
         "spacelift": {
-            "manage_state": default(config.get("generator.spacelift.manage_state"), True)
+            "manage_state": set_default(config.get("generator.spacelift.manage_state"), True)
         }, "github": {
-            "custom_app": default(config.get("generator.github.custom_app"), False)
+            "custom_app": set_default(config.get("generator.github.custom_app"), False)
         },
-        "custom_runner_image": default(config.get("generator.custom_runner_image"),
+        "custom_runner_image": set_default(config.get("generator.custom_runner_image"),
                                        "SPACELIFT_DEFAULT_INVALID"),
         "modules": {
-            "default_branch": default(config.get("generator.modules.default_branch"), ""),
+            "default_branch": set_default(config.get("generator.modules.default_branch"), ""),
         }
     }
 

--- a/spacemk/exporters/terraform.py
+++ b/spacemk/exporters/terraform.py
@@ -1,9 +1,9 @@
 # ruff: noqa: PERF401
 import json
 import logging
+import os
 import re
 import time
-import os
 from http import HTTPStatus
 from pathlib import Path
 
@@ -295,7 +295,7 @@ class TerraformExporter(BaseExporter):
 
         logging.info("Stop downloading state files")
 
-    def _enrich_variable_set_data(self, data: dict) -> dict:
+    def _enrich_variable_set_data(self, data: dict) -> dict: # noqa: PLR0912, PLR0915
         def reset_variable_set_relationships(var_set_id: str, variable_set_relationship_backup: dict) -> None:
 
             request = {}
@@ -462,7 +462,8 @@ class TerraformExporter(BaseExporter):
                         }
                     )
 
-                    logging.info(f"Trigger a plan for the '{organization.get('id')}/{new_workspace.get('id')}' workspace")
+                    logging.info(f"Trigger a plan for the '{organization.get('id')}/{new_workspace.get('id')}' "
+                                 f"workspace")
                     run_data = self._extract_data_from_api(
                         method="POST",
                         path="/runs",
@@ -1272,7 +1273,9 @@ class TerraformExporter(BaseExporter):
                                     "_migration_id": self._generate_migration_id(project.get("id"))
                                 },
                                 "context": {
-                                    "_migration_id": self._generate_migration_id(f"{project.get('id')}_{variable_set.get('id')}"),
+                                    "_migration_id": self._generate_migration_id(
+                                        f"{project.get('id')}_{variable_set.get('id')}"
+                                    ),
                                 },
                             },
                             "_source_id": f"{project.get('id')}_{variable.get('id')}",
@@ -1291,10 +1294,14 @@ class TerraformExporter(BaseExporter):
                         "_migration_id": self._generate_migration_id(variable.get("id")),
                         "_relationships": {
                             "space": {
-                                "_migration_id": self._generate_migration_id(variable_set.get("relationships.organization.data.id"))
+                                "_migration_id": self._generate_migration_id(
+                                    variable_set.get("relationships.organization.data.id")
+                                )
                             },
                             "context": {
-                                "_migration_id": self._generate_migration_id(variable.get("relationships.varset.data.id"))
+                                "_migration_id": self._generate_migration_id(
+                                    variable.get("relationships.varset.data.id")
+                                )
                             },
                         },
                         "_source_id": variable.get("id"),
@@ -1323,7 +1330,9 @@ class TerraformExporter(BaseExporter):
                         "_migration_id": self._generate_migration_id(variable_set.get("id")),
                         "_relationships": {
                             "space": {
-                                "_migration_id": self._generate_migration_id(variable_set.get("relationships.organization.data.id"))
+                                "_migration_id": self._generate_migration_id(
+                                    variable_set.get("relationships.organization.data.id")
+                                )
                             },
                             "stacks": [],  # The list is empty because it will be auto-attached to all stacks
                         },
@@ -1376,7 +1385,9 @@ class TerraformExporter(BaseExporter):
                             "_migration_id": self._generate_migration_id(variable_set.get("id")),
                             "_relationships": {
                                 "space": {
-                                    "_migration_id": self._generate_migration_id(variable_set.get("relationships.organization.data.id"))
+                                    "_migration_id": self._generate_migration_id(
+                                            variable_set.get("relationships.organization.data.id")
+                                        )
                                 },
                                 "stacks": stacks,
                             },


### PR DESCRIPTION
Added support for variable sets in TFC

The way this works:
1. For every organization it will create a new workspace called "SMK" in the default project
  - The SMK workspace will, initially, be setup with a "remote" runner.
  - The SMK workspace will be setup as a cli driven workflow
2. Using a new docker image, `terraform-push` we will run a quick apply with a null resource.
  - This is because the migration kit dies if there is no state in the workspace.
3. We will then update the SMK workspace to use the SMK agent instead of "remote"
4. We will list every variable set in the organization
5. We will backup the variable sets current relationships
6. We will update the variable sets relationship to the SMK workspace only and set it to `priority` to ensure no auto attaching variables will overwrite the ones from this variable set.
7. We will trigger a plan on the SMK agent and capture the environment
8. We will loop through all the variables and see if any of them correspond with sensitive variables in the current variable set, if they do we set that value in `data.json`
9. We reset the variable sets relationships back to what they were in the backup taken previously.
10. we delete the SMK workspace and agent pool
11. we stop any locally running docker containers