### PR TITLE
feat: settings during code generation

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -16,7 +16,7 @@ generator:
 #  # Default: false
 #  github:
 #    custom_app: false
-#
+
 #  # If you want spacelift to manage your state set to `true`.
 #  # If you want to use a third-party backend, like s3, set to `false`.
 #  # Default: true

--- a/config.yml.example
+++ b/config.yml.example
@@ -13,6 +13,12 @@ generator:
   extra_vars:
     foo: bar # "{{ extra_vars.foo }}" in a template will be replaced by "bar"
 
+    # If you use a custom app in github with spacelift, set this to `true`.
+    # If you use the marketplace github app with spacelift, set this to `false`.
+    # Default: false
+    github:
+      customApp: false
+
 github:
   api_token:
   endpoint: https://api.github.com

--- a/config.yml.example
+++ b/config.yml.example
@@ -15,7 +15,7 @@ generator:
 #  # If you use the marketplace github app with spacelift, set this to `false`.
 #  # Default: false
 #  github:
-#    customApp: false
+#    custom_app: false
 #
 #  # If you want spacelift to manage your state set to `true`.
 #  # If you want to use a third-party backend, like s3, set to `false`.

--- a/config.yml.example
+++ b/config.yml.example
@@ -10,6 +10,19 @@ exporter:
       workspaces: ^example-.*$
 
 generator:
+
+#  # If you use a custom app in github with spacelift, set this to `true`.
+#  # If you use the marketplace github app with spacelift, set this to `false`.
+#  # Default: false
+#  github:
+#    customApp: false
+#
+#  # If you want spacelift to manage your state set to `true`.
+#  # If you want to use a third-party backend, like s3, set to `false`.
+#  # Default: true
+#  spacelift:
+#    manage_state: true
+
   extra_vars:
     foo: bar # "{{ extra_vars.foo }}" in a template will be replaced by "bar"
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -26,12 +26,6 @@ generator:
   extra_vars:
     foo: bar # "{{ extra_vars.foo }}" in a template will be replaced by "bar"
 
-    # If you use a custom app in github with spacelift, set this to `true`.
-    # If you use the marketplace github app with spacelift, set this to `false`.
-    # Default: false
-    github:
-      customApp: false
-
 github:
   api_token:
   endpoint: https://api.github.com

--- a/spacemk/commands/generate.py
+++ b/spacemk/commands/generate.py
@@ -16,9 +16,13 @@ def generate(config):
     def default(value, default):
         return value if value is not None else default
 
-    spacelift = default(config.get("generator.spacelift"), {"manage_state": True})
-    github = default(config.get("generator.github"), {"custom_app": False})
-    generation_config = {"spacelift": spacelift, "github": github}
+    generation_config = {
+        "spacelift": {
+            "manage_state": default(config.get("generator.spacelift.manage_state"), True)
+        }, "github": {
+            "custom_app": default(config.get("generator.github.custom_app"), False)
+        }
+    }
 
     generator = Generator()
     generator.generate(extra_vars=config.get("generator.extra_vars"), generation_config=generation_config)

--- a/spacemk/commands/generate.py
+++ b/spacemk/commands/generate.py
@@ -13,5 +13,12 @@ from spacemk.generator import Generator
 )
 @pass_meta_key("config")
 def generate(config):
+    def default(value, default):
+        return value if value is not None else default
+
+    spacelift = default(config.get("generator.spacelift"), {"manage_state": True})
+    github = default(config.get("generator.github"), {"custom_app": False})
+    generation_config = {"spacelift": spacelift, "github": github}
+
     generator = Generator()
-    generator.generate(extra_vars=config.get("generator.extra_vars"))
+    generator.generate(extra_vars=config.get("generator.extra_vars"), generation_config=generation_config)

--- a/spacemk/commands/generate.py
+++ b/spacemk/commands/generate.py
@@ -13,8 +13,8 @@ from spacemk.generator import Generator
 )
 @pass_meta_key("config")
 def generate(config):
-    def default(value, default):
-        return value if value is not None else default
+    def default(value, _default):
+        return value if value is not None else _default
 
     generation_config = {
         "spacelift": {

--- a/spacemk/generator.py
+++ b/spacemk/generator.py
@@ -139,7 +139,7 @@ class Generator:
         data = self._load_data()
         data = self._process_data(data)
         self._generate_code(
-            data=data, 
+            data=data,
             extra_vars=extra_vars,
             template_name=template_name,
             generation_config=generation_config

--- a/spacemk/generator.py
+++ b/spacemk/generator.py
@@ -62,8 +62,9 @@ class Generator:
         else:
             logging.info("Formatted generated Terraform code")
 
-    def _generate_code(self, data: dict, extra_vars: dict, template_name: str):
+    def _generate_code(self, data: dict, extra_vars: dict, template_name: str, generation_config: dict):
         data["extra_vars"] = extra_vars
+        data["generation_config"] = generation_config
 
         current_file_path = Path(__file__).parent.resolve()
 
@@ -123,15 +124,17 @@ class Generator:
         else:
             logging.info("Generated Terraform code is valid")
 
-    def generate(self, extra_vars: Optional[dict] = None, template_name: str = "main.tf.jinja"):
+    def generate(self, extra_vars: Optional[dict] = None, template_name: str = "main.tf.jinja", generation_config: dict = None):
         """Generate source code for managing Spacelift entities"""
 
+        if generation_config is None:
+            generation_config = {}
         if extra_vars is None:
             extra_vars = {}
 
         self._check_requirements()
         data = self._load_data()
         data = self._process_data(data)
-        self._generate_code(data=data, extra_vars=extra_vars, template_name=template_name)
+        self._generate_code(data=data, extra_vars=extra_vars, template_name=template_name, generation_config=generation_config)
         self._format_code()
         self._validate_code()

--- a/spacemk/generator.py
+++ b/spacemk/generator.py
@@ -124,7 +124,10 @@ class Generator:
         else:
             logging.info("Generated Terraform code is valid")
 
-    def generate(self, extra_vars: Optional[dict] = None, template_name: str = "main.tf.jinja", generation_config: dict = None):
+    def generate(self,
+                 extra_vars: Optional[dict] = None,
+                 template_name: str = "main.tf.jinja",
+                 generation_config: Optional[dict] = None):
         """Generate source code for managing Spacelift entities"""
 
         if generation_config is None:
@@ -135,6 +138,11 @@ class Generator:
         self._check_requirements()
         data = self._load_data()
         data = self._process_data(data)
-        self._generate_code(data=data, extra_vars=extra_vars, template_name=template_name, generation_config=generation_config)
+        self._generate_code(
+            data=data, 
+            extra_vars=extra_vars,
+            template_name=template_name,
+            generation_config=generation_config
+        )
         self._format_code()
         self._validate_code()

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -99,9 +99,14 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   {% endif %}
 
   {% if stack.vcs.provider == "github_custom" %}
+  {% if extra_vars is defined
+    and extra_vars.github is defined
+    and extra_vars.github.customApp is defined
+    and extra_vars.github.customApp %}
   github_enterprise {
     {{ argument("namespace", stack.vcs.namespace) }}
   }
+  {% endif %}
   {% elif stack.vcs.provider %}
   {{ stack.vcs.provider }} {
     {{ argument("namespace", stack.vcs.namespace) }}
@@ -261,9 +266,14 @@ resource "spacelift_module" "{{ module._relationships.space._migration_id }}_{{ 
   {% block module_arguments_extra scoped %}{% endblock %}
 
   {% if module.vcs.provider == "github_custom" %}
+  {% if extra_vars is defined
+    and extra_vars.github is defined
+    and extra_vars.github.customApp is defined
+    and extra_vars.github.customApp %}
   github_enterprise {
     {{ argument("namespace", module.vcs.namespace) }}
   }
+  {% endif %}
   {% endif %}
 }
 {% block module_extra scoped %}{% endblock %}

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -98,7 +98,7 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   {{ argument("runner_image ", extra_vars.custom_terraform_runner_image ~ ":" ~ stack.terraform.version, required=True) }}
   {% endif %}
 
-  {% if stack.vcs.provider == "github_custom" and generation.github.custom_app %}
+  {% if stack.vcs.provider == "github_custom" and generation_config.github.custom_app %}
   github_enterprise {
     {{ argument("namespace", stack.vcs.namespace) }}
   }

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -97,7 +97,7 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   {% if stack.terraform.workflow_tool == "CUSTOM" %}
   {{ argument("runner_image ", extra_vars.custom_terraform_runner_image ~ ":" ~ stack.terraform.version, required=True) }}
   {% endif %}
-  
+
   {% if stack.vcs.provider == "github_custom" and generation.github.custom_app %}
   github_enterprise {
     {{ argument("namespace", stack.vcs.namespace) }}

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -98,10 +98,12 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   {{ argument("runner_image ", extra_vars.custom_terraform_runner_image ~ ":" ~ stack.terraform.version, required=True) }}
   {% endif %}
 
-  {% if stack.vcs.provider == "github_custom" and generation_config.github.custom_app %}
+  {% if stack.vcs.provider == "github_custom" %}
+  {% if generation_config.github.custom_app %}
   github_enterprise {
     {{ argument("namespace", stack.vcs.namespace) }}
   }
+  {% endif %}
   {% elif stack.vcs.provider %}
   {{ stack.vcs.provider }} {
     {{ argument("namespace", stack.vcs.namespace) }}
@@ -260,10 +262,12 @@ resource "spacelift_module" "{{ module._relationships.space._migration_id }}_{{ 
   {{ argument("terraform_provider", module.terraform_provider) }}
   {% block module_arguments_extra scoped %}{% endblock %}
 
-  {% if module.vcs.provider == "github_custom" and generation_config.github.custom_app %}
+  {% if module.vcs.provider == "github_custom" %}
+  {% if generation_config.github.custom_app %}
   github_enterprise {
     {{ argument("namespace", module.vcs.namespace) }}
   }
+  {% endif %}
   {% endif %}
 }
 {% block module_extra scoped %}{% endblock %}

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -84,7 +84,7 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   {{ argument("description", stack.description) }}
   {{ argument("local_preview", stack.local_preview) }}
   {{ argument("labels", stack.labels) }}
-  {{ argument("manage_state", False) }}
+  {{ argument("manage_state", generation_config.spacelift.manage_state) }}
   {{ argument("name", stack.name, required=True) }}
   {{ argument("project_root", stack.vcs.project_root) }}
   {{ argument("repository", stack.vcs.repository, required=True) }}
@@ -97,12 +97,7 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   {% if stack.terraform.workflow_tool == "CUSTOM" %}
   {{ argument("runner_image ", extra_vars.custom_terraform_runner_image ~ ":" ~ stack.terraform.version, required=True) }}
   {% endif %}
-
-  {% if stack.vcs.provider == "github_custom" %}
-  {% if extra_vars is defined
-    and extra_vars.github is defined
-    and extra_vars.github.customApp is defined
-    and extra_vars.github.customApp %}
+  {% if stack.vcs.provider == "github_custom" and generation.github.custom_app %}
   github_enterprise {
     {{ argument("namespace", stack.vcs.namespace) }}
   }
@@ -264,12 +259,7 @@ resource "spacelift_module" "{{ module._relationships.space._migration_id }}_{{ 
   {{ argument("space_id", "spacelift_space." ~ module._relationships.space._migration_id ~ ".id", serialize=False) }}
   {{ argument("terraform_provider", module.terraform_provider) }}
   {% block module_arguments_extra scoped %}{% endblock %}
-
-  {% if module.vcs.provider == "github_custom" %}
-  {% if extra_vars is defined
-    and extra_vars.github is defined
-    and extra_vars.github.customApp is defined
-    and extra_vars.github.customApp %}
+  {% if module.vcs.provider == "github_custom" and generation_config.github.custom_app %}
   github_enterprise {
     {{ argument("namespace", module.vcs.namespace) }}
   }

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -97,6 +97,7 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   {% if stack.terraform.workflow_tool == "CUSTOM" %}
   {{ argument("runner_image ", extra_vars.custom_terraform_runner_image ~ ":" ~ stack.terraform.version, required=True) }}
   {% endif %}
+  
   {% if stack.vcs.provider == "github_custom" and generation.github.custom_app %}
   github_enterprise {
     {{ argument("namespace", stack.vcs.namespace) }}
@@ -259,6 +260,7 @@ resource "spacelift_module" "{{ module._relationships.space._migration_id }}_{{ 
   {{ argument("space_id", "spacelift_space." ~ module._relationships.space._migration_id ~ ".id", serialize=False) }}
   {{ argument("terraform_provider", module.terraform_provider) }}
   {% block module_arguments_extra scoped %}{% endblock %}
+
   {% if module.vcs.provider == "github_custom" and generation_config.github.custom_app %}
   github_enterprise {
     {{ argument("namespace", module.vcs.namespace) }}

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -102,7 +102,6 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   github_enterprise {
     {{ argument("namespace", stack.vcs.namespace) }}
   }
-  {% endif %}
   {% elif stack.vcs.provider %}
   {{ stack.vcs.provider }} {
     {{ argument("namespace", stack.vcs.namespace) }}
@@ -265,7 +264,6 @@ resource "spacelift_module" "{{ module._relationships.space._migration_id }}_{{ 
   github_enterprise {
     {{ argument("namespace", module.vcs.namespace) }}
   }
-  {% endif %}
   {% endif %}
 }
 {% block module_extra scoped %}{% endblock %}


### PR DESCRIPTION
This PR allows us to pass specific settings, with defaults, to our Jinja templates.

Added:
```yaml
generator:
  spacelift:
    manage_state: bool # Instructs the spacelift stacks to manage state or not
  github:
    custom_app: bool # Instructs Jinja to add a github_enterprise block or not
```

`github_enterprise` in a `spacelift_stack` is meant to be used when setting up a custom github application. Since there is no way for us to know beforehand how they set this up, adding it as a flag to the generator config.