### PR TITLE
feat: ensure migration ids dont start with a number

### DIFF
--- a/spacemk/exporters/terraform.py
+++ b/spacemk/exporters/terraform.py
@@ -199,7 +199,8 @@ class TerraformExporter(BaseExporter):
 
         def check_for_bsl_terraform(version):
             # Ensure version is not pessimistic
-            if version.startswith("~") or version.startswith("^") or version.startswith(">") or version.startswith("<") or version.startswith("="):
+            if (version.startswith("~") or version.startswith("^") or version.startswith(">")
+                or version.startswith("<") or version.startswith("=")):
                 # lets just default to true so we catch this during a migration.
                 # This can almost certainly be overridden.
                 return True, "Pessimistic version, unable to determine if it's BSL Terraform"

--- a/spacemk/exporters/terraform.py
+++ b/spacemk/exporters/terraform.py
@@ -1281,7 +1281,11 @@ class TerraformExporter(BaseExporter):
         return entity
 
     def _generate_migration_id(self, *args: str) -> str:
-        return slugify("_".join(args)).replace("-", "_")
+        result = slugify("_".join(args)).replace("-", "_")
+        # Terraform resource names must start with a letter or underscore
+        if result and result[0].isdigit():
+            result = "_" + result
+        return result
 
     def _get_plan(self, id_: str) -> dict:
         while True:


### PR DESCRIPTION
## Summary
Adds validation to ensure Terraform migration IDs never start with a number, which violates Terraform's resource naming constraints.

## Motivation
Terraform resource names must start with a letter or underscore. When generating migration IDs from slugified strings, it's possible to produce IDs that start with a digit (e.g., from stack names like "2024-production"), which causes Terraform validation errors during migration.

## Changes
- Modified `_generate_migration_id()` method to detect when the generated ID starts with a digit
- Prepends an underscore to numeric-starting IDs to ensure Terraform compliance

## Fixes
- Prevents Terraform validation errors when migrating resources with names that begin with numbers
- Ensures all generated migration IDs are valid Terraform identifiers