### PR TITLE
feat: faster exporting and iteration

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -6,14 +6,49 @@ exporter:
     # Specific to the Terraform exporter (exporter.name: terraform)
     api_endpoint: https://app.terraform.io
     api_token:
-    include:
-      workspaces: ^example-.*$
+
+    # The number of parallel agents to spin up locally when enriching data.
+    # this can be increased to speed up the enrichment process just know that it will increase the memory usage of the exporter.
+    # every worker will spin up its own docker container.
+    parallel_enrichment_workers: 1
+
+    # ┌─────────────────────────────────────────────────────────────────────────┐
+    # │ EXPORT-TIME FILTERING                                                   │
+    # │                                                                         │
+    # │ Filters applied during 'spacemk export' when fetching from TFC API.     │
+    # │ Use this to limit what gets saved to data.json.                         │
+    # │ Reduces API calls and data.json size for large TFC installations.       │
+    # │                                                                         │
+    # │ All patterns are regex. Only entities with names matching the pattern   │
+    # │ will be exported.                                                       │
+    # └─────────────────────────────────────────────────────────────────────────┘
+#    include:
+#      organizations: ^my-org$              # Filter TFC organizations by name
+#      workspaces: ^prod-.*$                # Filter workspaces by name
 
 #    # If you want to support variable sets, set this to `true`. This feature is experimental.
 #    # Default: false
 #    experimental_support_variable_sets: false
 
 generator:
+
+  # ┌─────────────────────────────────────────────────────────────────────────┐
+  # │ GENERATE-TIME FILTERING                                                 │
+  # │                                                                         │
+  # │ Filters applied during 'spacemk generate' when creating Terraform code. │
+  # │ Use this to control which entities from data.json get generated.        │
+  # │                                                                         │
+  # │ This allows you to run 'export' once and then run 'generate' multiple   │
+  # │ times with different filters without re-fetching from TFC.              │
+  # │                                                                         │
+  # │ All patterns are regex. Related entities are automatically filtered:    │
+  # │ - Filtering workspaces also filters their variables                     │
+  # │ - Filtering affects context attachments to stacks                       │
+  # │ - Spaces with no remaining stacks/modules are excluded                  │
+  # └─────────────────────────────────────────────────────────────────────────┘
+#  include:
+#    workspaces: ^prod-.*$                  # Filter stacks by workspace name
+#    modules: ^terraform-aws-.*$            # Filter modules by name
 
 #  # If you use a custom app in github with spacelift, set this to `true`.
 #  # If you use the marketplace github app with spacelift, set this to `false`.

--- a/spacemk/commands/generate.py
+++ b/spacemk/commands/generate.py
@@ -32,5 +32,11 @@ def generate(config):
         }
     }
 
+    include_config = config.get("generator.include", {})
+
     generator = Generator()
-    generator.generate(extra_vars=config.get("generator.extra_vars"), generation_config=generation_config)
+    generator.generate(
+        extra_vars=config.get("generator.extra_vars"),
+        generation_config=generation_config,
+        include_config=include_config
+    )

--- a/spacemk/generator.py
+++ b/spacemk/generator.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -95,8 +96,117 @@ class Generator:
     def _load_data(self) -> dict:
         return load_normalized_data()
 
-    def _process_data(self, data: dict) -> dict:
-        logging.info("No custom data processing defined. Skipping.")
+    def _filter_stacks(self, data: dict, pattern_str: str) -> set:
+        """Filter stacks by name pattern and return set of included stack IDs."""
+        pattern = re.compile(pattern_str)
+        original_count = len(data.get("stacks", []))
+        data["stacks"] = [s for s in data.get("stacks", []) if pattern.match(s.get("name", ""))]
+        logging.info(f"Filtered stacks: {original_count} -> {len(data['stacks'])} (pattern: {pattern_str})")
+        return {s.get("_source_id") for s in data.get("stacks", [])}
+
+    def _get_relationship_id(self, obj: dict, relationship_name: str) -> str | None:
+        """Extract _source_id from a relationship, handling both dict and string formats."""
+        rel = obj.get("_relationships", {}).get(relationship_name)
+        if rel is None:
+            return None
+        if isinstance(rel, dict):
+            return rel.get("_source_id")
+        return rel
+
+    def _filter_stack_variables(self, data: dict, included_stack_ids: set) -> None:
+        """Filter stack_variables to only those belonging to included stacks."""
+        if not data.get("stack_variables"):
+            return
+        original_count = len(data["stack_variables"])
+        data["stack_variables"] = [
+            v for v in data["stack_variables"]
+            if self._get_relationship_id(v, "stack") in included_stack_ids
+        ]
+        logging.info(f"Filtered stack_variables: {original_count} -> {len(data['stack_variables'])}")
+
+    def _filter_modules(self, data: dict, pattern_str: str) -> set:
+        """Filter modules by name pattern and return set of included module IDs."""
+        pattern = re.compile(pattern_str)
+        original_count = len(data.get("modules", []))
+        data["modules"] = [m for m in data.get("modules", []) if pattern.match(m.get("name", ""))]
+        logging.info(f"Filtered modules: {original_count} -> {len(data['modules'])} (pattern: {pattern_str})")
+        return {m.get("_source_id") for m in data.get("modules", [])}
+
+    def _filter_contexts(self, data: dict, included_stack_ids: set) -> set:
+        """Filter contexts keeping auto-attached ones and those attached to included stacks."""
+        if not data.get("contexts"):
+            return set()
+
+        original_count = len(data["contexts"])
+        filtered_contexts = []
+
+        for ctx in data["contexts"]:
+            labels = ctx.get("labels", [])
+            is_auto_attached = any("autoattach:" in str(label) for label in labels)
+
+            if is_auto_attached:
+                filtered_contexts.append(ctx)
+                continue
+
+            attached_stacks = ctx.get("_relationships", {}).get("stacks", [])
+            if attached_stacks:
+                filtered_attached = [s for s in attached_stacks if s.get("_source_id") in included_stack_ids]
+                if filtered_attached:
+                    ctx["_relationships"]["stacks"] = filtered_attached
+                    filtered_contexts.append(ctx)
+
+        data["contexts"] = filtered_contexts
+        logging.info(f"Filtered contexts: {original_count} -> {len(data['contexts'])}")
+        return {c.get("_source_id") for c in data.get("contexts", [])}
+
+    def _filter_context_variables(self, data: dict, included_context_ids: set) -> None:
+        """Filter context_variables to only those belonging to included contexts."""
+        if not data.get("context_variables"):
+            return
+        original_count = len(data["context_variables"])
+        data["context_variables"] = [
+            v for v in data["context_variables"]
+            if self._get_relationship_id(v, "context") in included_context_ids
+        ]
+        logging.info(f"Filtered context_variables: {original_count} -> {len(data['context_variables'])}")
+
+    def _filter_spaces(self, data: dict) -> None:
+        """Filter spaces to only those containing included stacks or modules."""
+        if not data.get("spaces"):
+            return
+
+        space_ids_with_stacks = {self._get_relationship_id(s, "space") for s in data.get("stacks", [])}
+        space_ids_with_modules = {self._get_relationship_id(m, "space") for m in data.get("modules", [])}
+        included_space_ids = space_ids_with_stacks | space_ids_with_modules
+
+        original_count = len(data["spaces"])
+        data["spaces"] = [s for s in data["spaces"] if s.get("_source_id") in included_space_ids]
+        logging.info(f"Filtered spaces: {original_count} -> {len(data['spaces'])}")
+
+    def _process_data(self, data: dict, include_config: Optional[dict] = None) -> dict:
+        """Filter data based on include patterns from config."""
+        if not include_config:
+            logging.info("No include filters specified. Using all data.")
+            return data
+
+        logging.info("Start filtering data based on include patterns")
+
+        if include_config.get("workspaces"):
+            included_stack_ids = self._filter_stacks(data, include_config["workspaces"])
+        else:
+            included_stack_ids = {s.get("_source_id") for s in data.get("stacks", [])}
+
+        self._filter_stack_variables(data, included_stack_ids)
+
+        if include_config.get("modules"):
+            self._filter_modules(data, include_config["modules"])
+
+        included_context_ids = self._filter_contexts(data, included_stack_ids)
+        self._filter_context_variables(data, included_context_ids)
+        self._filter_spaces(data)
+
+        logging.info("Stop filtering data based on include patterns")
+
         return data
 
     def _save_to_file(self, filename: str, content: str):
@@ -127,9 +237,8 @@ class Generator:
     def generate(self,
                  extra_vars: Optional[dict] = None,
                  template_name: str = "main.tf.jinja",
-                 generation_config: Optional[dict] = None):
-        """Generate source code for managing Spacelift entities"""
-
+                 generation_config: Optional[dict] = None,
+                 include_config: Optional[dict] = None):
         if generation_config is None:
             generation_config = {}
         if extra_vars is None:
@@ -137,7 +246,7 @@ class Generator:
 
         self._check_requirements()
         data = self._load_data()
-        data = self._process_data(data)
+        data = self._process_data(data, include_config)
         self._generate_code(
             data=data,
             extra_vars=extra_vars,

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -102,7 +102,8 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
 
   {% if stack.terraform.workflow_tool == "CUSTOM" %}
   {% if generation_config.custom_runner_image == "SPACELIFT_DEFAULT_INVALID" %}
-  {% raise "generator.custom_runner_image is required for stacks with custom Terraform workflow tool." %}
+  // Add the stack name into the issue so we know what stack caused the issue
+  {% raise "generator.custom_runner_image is required for stacks with custom Terraform workflow tool. Stack Causing Issue: " + stack.name %}
   {% endif %}
   {{ argument("runner_image ", generation_config.custom_runner_image ~ ":" ~ stack.terraform.version, required=True) }}
   {% endif %}


### PR DESCRIPTION
## Summary
This PR introduces parallel processing for workspace enrichment and a two-stage filtering system that significantly improves performance and flexibility when migrating from Terraform Cloud/Enterprise to Spacelift.

## Motivation
Large TFC/TFE installations with hundreds or thousands of workspaces face two major pain points:

1. **Slow enrichment**: Processing sensitive variables requires running a Terraform plan for each workspace sequentially, which can take hours for large installations
2. **Inflexible workflows**: Users had to re-export all data from TFC every time they wanted to generate Terraform code for a different subset of workspaces

## Changes

### Performance: Parallel Workspace Enrichment
- Added `parallel_enrichment_workers` configuration option (default: 1)
- Refactored `_enrich_workspace_variable_data()` to use `ThreadPoolExecutor` for concurrent processing
- Each worker gets its own Docker container running the TFC agent
- Thread-safe data access using locks to prevent race conditions
- Extracted workspace processing into `_process_single_workspace_enrichment()` for better separation of concerns

**Impact**: On installations with many workspaces, this can reduce enrichment time from hours to minutes by processing multiple workspaces concurrently.

### Flexibility: Two-Stage Filtering System

**Export-Time Filtering** (`exporter.include.*`):
- Applied during `spacemk export` when fetching from TFC API
- Filters organizations and workspaces before saving to `data.json`
- Reduces API calls and data.json size for large installations
- Use when you know exactly what you want to migrate upfront

**Generate-Time Filtering** (`generator.include.*`):
- Applied during `spacemk generate` when creating Terraform code
- Filters workspaces, modules, contexts, and related entities from existing `data.json`
- Enables iterating on different subsets without re-exporting
- Related entities are automatically filtered (variables, context attachments, empty spaces)

**Impact**: Export once, generate many times with different filters. This supports iterative migration approaches where you test with a small subset before migrating everything.

### Configuration Documentation
Enhanced `config.yml.example` with detailed comments explaining:
- When to use export-time vs generate-time filtering
- How cascading filters work (e.g., filtering stacks also filters their variables)
- Configuration options for parallel workers

### Code Quality Improvements
- Better error messages that include the stack name when configuration is missing
- Improved cleanup handling with `pending_restorations` tracking
- Removed redundant container logs when containers are already stopped
- Proper tempdir management for parallel workers

## Features

### Parallel Enrichment
```yaml
exporter:
  name: terraform
  terraform:
    # Speed up enrichment by processing multiple workspaces concurrently
    parallel_enrichment_workers: 5
```

### Export-Time Filtering (Reduce API Calls)
```yaml
exporter:
  name: terraform
  terraform:
    include:
      organizations: ^my-org$
      workspaces: ^prod-.*$
```

### Generate-Time Filtering (Iterate Without Re-Exporting)
```yaml
generator:
  include:
    workspaces: ^prod-.*$        # Only generate prod stacks
    modules: ^terraform-aws-.*$  # Only AWS modules
```

## Testing Recommendations

1. **Parallel Processing**: Test with `parallel_enrichment_workers` set to different values (1, 3, 5) to ensure thread safety
2. **Filter Combinations**: Verify cascading filters work correctly (filtering stacks removes their variables, filtering contexts updates stack attachments)
3. **Error Recovery**: Ensure workspace exec mode is properly restored even when enrichment fails mid-process
4. **Large Installations**: Test with TFC orgs that have 100+ workspaces to verify performance improvements

## Breaking Changes
None - all new features are opt-in via configuration.

## Notes
- Commented out `_download_state_files(data)` in the enrichment flow (line 865) - appears to be intentional for testing but should be reviewed
- The parallel workers share a single temp directory for log files, which is cleaned up after all workers complete