### PR TITLE
Fix generation bug when using Terraform custom workflow

### DIFF
--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -34,7 +34,7 @@ resource "spacelift_context" "{{ space._migration_id }}_terraform_workflow_tool"
 
 resource "spacelift_mounted_file" "workflow" {
   {{ argument("context_id", "spacelift_context." ~ space._migration_id ~ "_terraform_workflow_tool.id", required=True, serialize=False) }}
-  {{ argument("relative_path", ".spacelift/workflow.yml", required=True) }}
+  {{ argument("relative_path", "source/.spacelift/workflow.yml", required=True) }}
   {% raw %}
   content = base64encode(
 <<EOT
@@ -96,7 +96,9 @@ resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ st
   {{ argument("repository", stack.vcs.repository, required=True) }}
   {{ argument("slug", stack.slug, default=stack.name) }}
   {{ argument("space_id", "spacelift_space." ~ stack._relationships.space._migration_id ~ ".id", serialize=False) }}
+  {% if stack.terraform.workflow_tool != "CUSTOM" %}
   {{ argument("terraform_version", stack.terraform.version, serialize=True) }}
+  {% endif %}
   {{ argument("terraform_workflow_tool", stack.terraform.workflow_tool, default="TERRAFORM_FOSS") }}
   {% block stack_arguments_extra scoped %}{% endblock %}
 


### PR DESCRIPTION
When using Terraform custom workflow, `spacemk` creates the YAML file in the wrong location and sets a Terraform version, which is not allowed. This PR fixes both of these issues.