### PR TITLE
fix(export): prevent crash when retrieving agent container logs

### DIFF
--- a/spacemk/exporters/terraform.py
+++ b/spacemk/exporters/terraform.py
@@ -16,6 +16,7 @@ import requests
 import semver
 from benedict import benedict
 from python_on_whales import Container, docker
+from python_on_whales.exceptions import DockerException, NoSuchContainer
 from requests_toolbelt.utils import dump as request_dump
 from slugify import slugify
 
@@ -572,9 +573,11 @@ class TerraformExporter(BaseExporter):
                     reset_variable_set_relationships(var_set_id, variable_set_relationship_backup)
                     var_set_reset = True
 
-                if agent_container.exists() and agent_container.state.running:
+                try:
                     logging.debug(f"Local TFC/TFE agent Docker container '{agent_container_id}' logs:")
                     logging.debug(agent_container.logs())
+                except (DockerException, NoSuchContainer) as e:
+                    logging.debug(f"Could not retrieve logs for container '{agent_container_id}': {e}")
 
         finally:
             logging.info("Stop enriching variable_set data")
@@ -839,9 +842,11 @@ class TerraformExporter(BaseExporter):
                             logging.exception(f"Failed to process workspace '{workspace_id}'")
 
                 for container in agent_containers:
-                    if container.exists() and container.state.running:
+                    try:
                         logging.debug(f"Local TFC/TFE agent Docker container '{container.id}' logs:")
                         logging.debug(container.logs())
+                    except (DockerException, NoSuchContainer) as e:
+                        logging.debug(f"Could not retrieve logs for container '{container.id}': {e}")
 
             finally:
                 logging.info(f"Stop local TFC/TFE agent(s) for organization '{organization_id}'")


### PR DESCRIPTION
The post-processing debug log dump in `_enrich_workspace_variable_data` and `_enrich_variable_set_data` calls `container.logs()` after all workspaces have been processed. The existing guard relies on cached state from `python_on_whales`, so if the agent container has exited or been marked for removal between the check and the logs call, Docker raises:

```plain
Error response from daemon: can not get logs from container which is dead or marked for removal
```

This bubbles up as an unhandled `DockerException` and crashes the entire export at the very end - after all the actual enrichment work has already succeeded.

Since this log dump is purely for debug output, wrap the `logs()` call in a `try/except` and log the failure at debug level instead of letting it abort the run.