### PR TITLE
fix(generate): set default branch to `main` and improve empty string handling

### DIFF
--- a/spacemk/commands/generate.py
+++ b/spacemk/commands/generate.py
@@ -14,7 +14,7 @@ from spacemk.generator import Generator
 @pass_meta_key("config")
 def generate(config):
     def set_default(value, _default):
-        return value if value is not None else _default
+        return value if value else _default
 
     generation_config = {
         "spacelift": {
@@ -25,10 +25,10 @@ def generate(config):
         "custom_runner_image": set_default(config.get("generator.custom_runner_image"),
                                        "SPACELIFT_DEFAULT_INVALID"),
         "modules": {
-            "default_branch": set_default(config.get("generator.modules.default_branch"), ""),
+            "default_branch": set_default(config.get("generator.modules.default_branch"), "main"),
         },
         "stacks": {
-            "default_branch": set_default(config.get("generator.stacks.default_branch"), ""),
+            "default_branch": set_default(config.get("generator.stacks.default_branch"), "main"),
         }
     }
 

--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -82,7 +82,7 @@ EOT
 {% if stack.vcs.repository %}
 resource "spacelift_stack" "{{ stack._relationships.space._migration_id }}_{{ stack._migration_id }}" {
   {{ argument("auto_deploy", stack.auto_deploy, default=False) }}
-  {%  if  stack.vcs.branch == ""%}
+  {% if not stack.vcs.branch %}
   {{ argument("branch", generation_config.stacks.default_branch, required=True) }}
   {% else %}
   {{ argument("branch", stack.vcs.branch, required=True) }}
@@ -272,7 +272,7 @@ resource "spacelift_environment_variable" "{{ variable._relationships.space._mig
 {% if module.status == "setup_complete" and module.visibility == "private" %}
 resource "spacelift_module" "{{ module._relationships.space._migration_id }}_{{ module._migration_id }}" {
 
-  {%  if  module.vcs.branch == ""%}
+  {% if not module.vcs.branch %}
   {{ argument("branch", generation_config.modules.default_branch, required=True) }}
   {% else %}
   {{ argument("branch", module.vcs.branch, required=True) }}


### PR DESCRIPTION
When a Terraform Cloud workspace or private registry module has no branch set on its VCS config (TFC infers the repo's default branch in that case), `spacemk generate` produced invalid Terraform:

```shell
Error: [{{} branch}] must not be an empty string

  with spacelift_stack.platform_testtd_20260416_02_dev,
  on main.tf line 76, in resource "spacelift_stack" "platform_testtd_20260416_02_dev":
  76:   branch      = ""
```

The Spacelift provider rejects an empty branch, but `generator.stacks.default_branch` and `generator.modules.default_branch` both defaulted to `""`, so the fallback path in `base.tf.jinja` emitted an invalid resource.

This change defaults both to `main` - a sensible value that matches the modern repo-default convention and produces valid Terraform out of the box. Users who want a different default can still override it via `generator.stacks.default_branch` / `generator.modules.default_branch` in their config.

 Also normalises the branch fallback check in `base.tf.jinja` to use truthiness so both `None` and `""` fall through to the default — previously only `""` did, and `None` would have rendered as `null`.