### PR TITLE
fix(templates): prevent duplicate workflow resource names

### DIFF
--- a/spacemk/templates/base.tf.jinja
+++ b/spacemk/templates/base.tf.jinja
@@ -32,7 +32,7 @@ resource "spacelift_context" "{{ space._migration_id }}_terraform_workflow_tool"
   {{ argument("labels", ["migration_class:" + class]) }}
 }
 
-resource "spacelift_mounted_file" "workflow" {
+resource "spacelift_mounted_file" "{{ space._migration_id }}_workflow" {
   {{ argument("context_id", "spacelift_context." ~ space._migration_id ~ "_terraform_workflow_tool.id", required=True, serialize=False) }}
   {{ argument("relative_path", "source/.spacelift/workflow.yml", required=True) }}
   {% raw %}


### PR DESCRIPTION
When two or more spaces have stacks using a custom Terraform workflow tool, `spacemk generate` produces invalid Terraform:

```shell
Error: Duplicate resource "spacelift_mounted_file" configuration

  on main.tf line 87:
  87: resource "spacelift_mounted_file" "workflow" {

A spacelift_mounted_file resource named "workflow" was already declared at
main.tf:35,1-45.
```

The fix mirrors the namespacing already used by the surrounding `spacelift_context` and `spacelift_context_attachment` resources.

Single-space migrations are unaffected. Multi-space migrations now generate valid HCL.